### PR TITLE
fix object allocs

### DIFF
--- a/dfa.go
+++ b/dfa.go
@@ -98,11 +98,12 @@ func (d *iDFABuilder) build(nfa *iNFA) iDFA {
 		rep.matches[id] = append(rep.matches[id], nfa.states[id].matches...)
 		fail := nfa.states[id].fail
 
-		nfa.iterAllTransitions(&byteClasses, stateID(id), func(tr *next) {
-			if tr.id == failedStateID {
-				tr.id = nfaNextStateMemoized(nfa, &rep, stateID(id), fail, tr.key)
+		nfa.iterAllTransitions(&byteClasses, stateID(id), func(tr next) {
+			nextID := tr.id
+			if nextID == failedStateID {
+				nextID = nfaNextStateMemoized(nfa, &rep, stateID(id), fail, tr.key)
 			}
-			rep.setNextState(stateID(id), tr.key, tr.id)
+			rep.setNextState(stateID(id), tr.key, nextID)
 		})
 
 	}

--- a/nfa.go
+++ b/nfa.go
@@ -299,20 +299,20 @@ func (c *compiler) fillFailureTransitionsStandard() {
 		queue = queue[1:]
 		it := newIterTransitions(&c.nfa, id)
 
-		for next := it.next(); next != nil; next = it.next() {
-			if seen.contains(next.id) {
+		for tr, ok := it.next(); ok; tr, ok = it.next() {
+			if seen.contains(tr.id) {
 				continue
 			}
-			queue = append(queue, next.id)
-			seen.insert(next.id)
+			queue = append(queue, tr.id)
+			seen.insert(tr.id)
 
 			fail := it.nfa.state(id).fail
-			for it.nfa.state(fail).nextState(next.key) == failedStateID {
+			for it.nfa.state(fail).nextState(tr.key) == failedStateID {
 				fail = it.nfa.state(fail).fail
 			}
-			fail = it.nfa.state(fail).nextState(next.key)
-			it.nfa.state(next.id).fail = fail
-			it.nfa.copyMatches(fail, next.id)
+			fail = it.nfa.state(fail).nextState(tr.key)
+			it.nfa.state(tr.id).fail = fail
+			it.nfa.copyMatches(fail, tr.id)
 		}
 		it.nfa.copyEmptyMatches(id)
 	}
@@ -342,16 +342,16 @@ func (c *compiler) fillFailureTransitionsLeftmost() {
 		queue = queue[1:]
 		anyTrans := false
 		it := newIterTransitions(&c.nfa, item.id)
-		tr := it.next()
-		for tr != nil {
+		tr, ok := it.next()
+		for ok {
 			anyTrans = true
-			next := item.nextQueuedState(it.nfa, tr.id)
-			if seen.contains(next.id) {
-				tr = it.next()
+			nextQueued := item.nextQueuedState(it.nfa, tr.id)
+			if seen.contains(nextQueued.id) {
+				tr, ok = it.next()
 				continue
 			}
-			queue = append(queue, next)
-			seen.insert(next.id)
+			queue = append(queue, nextQueued)
+			seen.insert(nextQueued.id)
 
 			fail := it.nfa.state(item.id).fail
 			for it.nfa.state(fail).nextState(tr.key) == failedStateID {
@@ -359,22 +359,22 @@ func (c *compiler) fillFailureTransitionsLeftmost() {
 			}
 			fail = it.nfa.state(fail).nextState(tr.key)
 
-			if next.matchAtDepth != nil {
+			if nextQueued.matchAtDepth != nil {
 				failDepth := it.nfa.state(fail).depth
-				nextDepth := it.nfa.state(next.id).depth
-				if nextDepth-*next.matchAtDepth+1 > failDepth {
-					it.nfa.state(next.id).fail = deadStateID
-					tr = it.next()
+				nextDepth := it.nfa.state(nextQueued.id).depth
+				if nextDepth-*nextQueued.matchAtDepth+1 > failDepth {
+					it.nfa.state(nextQueued.id).fail = deadStateID
+					tr, ok = it.next()
 					continue
 				}
 
-				if start.id == it.nfa.state(next.id).fail {
+				if start.id == it.nfa.state(nextQueued.id).fail {
 					panic("states that are match states or follow match states should never have a failure transition back to the start state in leftmost searching")
 				}
 			}
-			it.nfa.state(next.id).fail = fail
-			it.nfa.copyMatches(fail, next.id)
-			tr = it.next()
+			it.nfa.state(nextQueued.id).fail = fail
+			it.nfa.copyMatches(fail, nextQueued.id)
+			tr, ok = it.next()
 		}
 		if !anyTrans && it.nfa.state(item.id).isMatch() {
 			it.nfa.state(item.id).fail = deadStateID
@@ -405,7 +405,7 @@ func (n *iNFA) getTwo(i stateID, j stateID) (*state, *state) {
 	return &after[0], &before[j]
 }
 
-func (n *iNFA) iterAllTransitions(byteClasses *byteClasses, id stateID, f func(tr *next)) {
+func (n *iNFA) iterAllTransitions(byteClasses *byteClasses, id stateID, f func(tr next)) {
 	n.states[id].trans.iterAll(byteClasses, f)
 }
 
@@ -428,18 +428,18 @@ type next struct {
 	id  stateID
 }
 
-func (i *iterTransitions) next() *next {
+func (i *iterTransitions) next() (next, bool) {
 	sparse := i.nfa.states[int(i.stateId)].trans.sparse
 	if sparse != nil {
 		if i.cur >= len(sparse.inner) {
-			return nil
+			return next{}, false
 		}
 		ii := i.cur
 		i.cur += 1
-		return &next{
+		return next{
 			key: sparse.inner[ii].b,
 			id:  sparse.inner[ii].s,
-		}
+		}, true
 	}
 
 	dense := i.nfa.states[int(i.stateId)].trans.dense
@@ -452,13 +452,13 @@ func (i *iterTransitions) next() *next {
 		id := dense.inner[b]
 		i.cur += 1
 		if id != failedStateID {
-			return &next{
+			return next{
 				key: b,
 				id:  id,
-			}
+			}, true
 		}
 	}
-	return nil
+	return next{}, false
 }
 
 type queuedSet struct {
@@ -682,18 +682,18 @@ type transitions struct {
 	dense  *dense
 }
 
-func sparseIter(trans []innerSparse, f func(*next)) {
+func sparseIter(trans []innerSparse, f func(next)) {
 	var byte16 uint16
 
 	for _, tr := range trans {
 		for byte16 < uint16(tr.b) {
-			f(&next{
+			f(next{
 				key: byte(byte16),
 				id:  failedStateID,
 			})
 			byte16 += 1
 		}
-		f(&next{
+		f(next{
 			key: tr.b,
 			id:  tr.s,
 		})
@@ -701,14 +701,14 @@ func sparseIter(trans []innerSparse, f func(*next)) {
 	}
 
 	for b := byte16; b < 256; b++ {
-		f(&next{
+		f(next{
 			key: byte(b),
 			id:  failedStateID,
 		})
 	}
 }
 
-func (t *transitions) iterAll(byteClasses *byteClasses, f func(tr *next)) {
+func (t *transitions) iterAll(byteClasses *byteClasses, f func(tr next)) {
 	if byteClasses.isSingleton() {
 		if t.sparse != nil {
 			sparseIter(t.sparse.inner, f)
@@ -716,7 +716,7 @@ func (t *transitions) iterAll(byteClasses *byteClasses, f func(tr *next)) {
 
 		if t.dense != nil {
 			for b := 0; b < 256; b++ {
-				f(&next{
+				f(next{
 					key: byte(b),
 					id:  t.dense.inner[b],
 				})
@@ -724,14 +724,15 @@ func (t *transitions) iterAll(byteClasses *byteClasses, f func(tr *next)) {
 		}
 	} else {
 		if t.sparse != nil {
-			var lastClass *byte
+			var lastClass byte
+			hasLastClass := false
 
-			sparseIter(t.sparse.inner, func(n *next) {
+			sparseIter(t.sparse.inner, func(n next) {
 				class := byteClasses.bytes[n.key]
 
-				if lastClass == nil || *lastClass != class {
-					cc := class
-					lastClass = &cc
+				if !hasLastClass || lastClass != class {
+					lastClass = class
+					hasLastClass = true
 					f(n)
 				}
 			})
@@ -745,7 +746,7 @@ func (t *transitions) iterAll(byteClasses *byteClasses, f func(tr *next)) {
 			}
 
 			for n := bcr.next(); n != nil; n = bcr.next() {
-				f(&next{
+				f(next{
 					key: *n,
 					id:  t.dense.inner[*n],
 				})


### PR DESCRIPTION
Hi!

I saw that this library was creating a bunch of object allocs, so I asked claude to make it more efficient.

Here is my prompt for claude code.

```
> /model 
  ⎿  Set model to opus (claude-opus-4-5-20251101)

> We use this library (aho-corastick for golang) and it consumes a lot of object allocations which exhausts our GC. Use your expertise in memory optimization to make this library 
use the minimum amount of allocations as possible, it is also permitted to use the like of sync.Pool etc. Here is a object alloc trace of what uses most memory   685            .  
         . func sparseIter(trans []innerSparse, f func(*next)) {
   686            .           .     var byte16 uint16
   687            .           .
   688            .           .     for _, tr := range trans {
   689            .           .         for byte16 < uint16(tr.b) {
   690     4.80 Bil    4.93 Bil             f(&next{
   691            .           .                 key: byte(byte16),
   692            .           .                 id:  failedStateID,
   693            .           .             })
   694            .           .             byte16 += 1
   695            .           .         }
   696     93.3 Mil    99.4 Mil         f(&next{
   697            .           .             key: tr.b,
   698            .           .             id:  tr.s,
   699            .           .         })
   700            .           .         byte16 += 1
   701            .           .     }
   702            .           .
   703            .           .     for b := byte16; b < 256; b++ {
   704     9.62 Bil    9.74 Bil         f(&next{
   705            .           .             key: byte(b),
   706            .           .             id:  failedStateID,
   707            .           .         })
   708            .           .     }
   709            .           . } 
```
